### PR TITLE
Fix favorites link retrieval for invalid index

### DIFF
--- a/src/main/kotlin/service/music/Favorites.kt
+++ b/src/main/kotlin/service/music/Favorites.kt
@@ -55,7 +55,7 @@ internal class Favorites {
 
         val index = extractIndex(event.message.content)
         if (index == null || index < 1) {
-            return sendErrorMessage(event, "Неправильный индекс").thenReturn(null.toString())
+            return sendErrorMessage(event, "Неправильный индекс").thenReturn(null)
         }
 
         return getFavoriteLink(memberId, index, event)


### PR DESCRIPTION
## Summary
- return `null` if favorites index is invalid rather than the string `"null"`

## Testing
- `./gradlew test` *(fails: Internal compiler error)*

------
https://chatgpt.com/codex/tasks/task_e_68406a4beb208322b836094461ea02b7