### PR TITLE
Rename RemoveOfFavorite to RemoveFromFavorite

### DIFF
--- a/src/main/kotlin/bot/Bot.kt
+++ b/src/main/kotlin/bot/Bot.kt
@@ -85,7 +85,7 @@ class Bot(id: String, private val apiKeyYouTube: String) {
 
         commands["pfavorite"] = PlayFavoriteCommand()
 
-        commands["rmfavorite"] = RemoveOfFavoriteCommand()
+        commands["rmfavorite"] = RemoveFromFavoriteCommand()
 
         commands["nowfavorite"] = NowFavoriteCommand()
 

--- a/src/main/kotlin/bot/command/music/change_state_player/favorites/RemoveFromFavoriteCommand.kt
+++ b/src/main/kotlin/bot/command/music/change_state_player/favorites/RemoveFromFavoriteCommand.kt
@@ -5,8 +5,8 @@ import bot.Command
 import discord4j.core.event.domain.message.MessageCreateEvent
 import reactor.core.publisher.Mono
 
-class RemoveOfFavoriteCommand : Command {
+class RemoveFromFavoriteCommand : Command {
     override fun execute(event: MessageCreateEvent?): Mono<Void?>? {
-        return event?.let { Bot.serviceComponent.getMusicService().removeOfFavorite(it) }
+        return event?.let { Bot.serviceComponent.getMusicService().removeFromFavorite(it) }
     }
 }

--- a/src/main/kotlin/service/music/Favorites.kt
+++ b/src/main/kotlin/service/music/Favorites.kt
@@ -61,7 +61,7 @@ internal class Favorites {
         return getFavoriteLink(memberId, index, event)
     }
 
-    fun removeOfFavorite(event: MessageCreateEvent): Mono<Void> {
+    fun removeFromFavorite(event: MessageCreateEvent): Mono<Void> {
         val memberId = event.message.author.map { it.id }.orElse(null) ?: return Mono.empty()
 
         val content = event.message.content

--- a/src/main/kotlin/service/music/MusicService.kt
+++ b/src/main/kotlin/service/music/MusicService.kt
@@ -232,8 +232,8 @@ class MusicService {
         }
     }
 
-    fun removeOfFavorite(event: MessageCreateEvent): Mono<Void?> {
-        return favorites.removeOfFavorite(event).then()
+    fun removeFromFavorite(event: MessageCreateEvent): Mono<Void?> {
+        return favorites.removeFromFavorite(event).then()
     }
 
     fun addToFavoritesCurrentTrack(event: MessageCreateEvent): Mono<Void?> {


### PR DESCRIPTION
## Summary
- rename command file from `RemoveOfFavoriteCommand` to `RemoveFromFavoriteCommand`
- update the command class name and its usages
- rename `removeOfFavorite` methods to `removeFromFavorite`

## Testing
- `./gradlew build` *(fails: java.lang.IllegalAccessError)*

------
https://chatgpt.com/codex/tasks/task_e_68406a4b43fc832295e695428b4a81a5