### PR TITLE
Add setup script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Discord Bot
+
+Этот проект представляет собой Discord-бота, написанного на Kotlin. Для сборки и запуска используется Gradle Wrapper.
+
+## Требования
+- Java 17 или новее
+- Доступ в интернет для загрузки зависимостей Gradle
+
+## Установка и сборка
+1. Убедитесь, что установлен JDK 17 или новее:
+   ```bash
+   java -version
+   ```
+2. Запустите скрипт `setup.sh`, который сделает файл `gradlew` исполнимым и выполнит сборку:
+   ```bash
+   ./setup.sh
+   ```
+   После выполнения в каталоге `build/libs` появится готовый jar-файл.
+
+## Запуск бота
+После сборки запустить бота можно так:
+```bash
+./gradlew run --args "<DISCORD_TOKEN> <YOUTUBE_API_KEY>"
+```
+где вместо `<DISCORD_TOKEN>` и `<YOUTUBE_API_KEY>` нужно подставить токен вашего бота и ключ YouTube API соответственно.
+
+Также можно запустить jar-файл напрямую:
+```bash
+java -jar build/libs/discord-bot-1.0-SNAPSHOT.jar <DISCORD_TOKEN> <YOUTUBE_API_KEY>
+```

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Simple setup script for the Discord bot project
+set -euo pipefail
+
+# Ensure the Gradle wrapper is executable
+chmod +x gradlew
+
+# Use Java 17 if available
+if command -v java >/dev/null; then
+  JAVA_VERSION=$(java -version 2>&1 | awk -F[\"._] '/version/ {print $2}')
+  if [ "$JAVA_VERSION" -lt 17 ]; then
+    echo "Java 17 or newer is required."
+    exit 1
+  fi
+else
+  echo "Java is not installed. Please install JDK 17 or higher."
+  exit 1
+fi
+
+# Build the project
+./gradlew build
+
+echo "Build finished. The resulting jar can be found in build/libs."
+
+echo "To run the bot after building, execute:"
+echo "  ./gradlew run --args \"<DISCORD_TOKEN> <YOUTUBE_API_KEY>\""
+


### PR DESCRIPTION
## Summary
- add `setup.sh` for building the bot
- document installation and run instructions in `README.md`

## Testing
- `sh gradlew -Dorg.gradle.jvmargs="-Xmx1536m -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8" test` *(fails: KAPT internal compiler error)*

------
https://chatgpt.com/codex/tasks/task_e_68406ac8b83c8322bc053381a64415c0