### PR TITLE
Fix music bot disconnect on join

### DIFF
--- a/src/main/kotlin/bot/Observers.kt
+++ b/src/main/kotlin/bot/Observers.kt
@@ -61,6 +61,12 @@ internal class Observers(private val commands: MutableMap<String, Command>) {
         val oldChannelId = event.old.orElse(null)?.channelId?.orElse(null)
         val currentChannelId = event.current.channelId.orElse(null)
 
+        // Ignore initial join events triggered by the bot itself to avoid
+        // a premature disconnect when voice state cache isn't updated yet
+        if (event.current.userId == selfId && oldChannelId == null) {
+            return Mono.empty()
+        }
+
         if (oldChannelId == null && currentChannelId == null) {
             println("No channel state change")
             return Mono.empty<Void>()

--- a/src/main/kotlin/bot/Observers.kt
+++ b/src/main/kotlin/bot/Observers.kt
@@ -61,8 +61,6 @@ internal class Observers(private val commands: MutableMap<String, Command>) {
         val oldChannelId = event.old.orElse(null)?.channelId?.orElse(null)
         val currentChannelId = event.current.channelId.orElse(null)
 
-        // Ignore initial join events triggered by the bot itself to avoid
-        // a premature disconnect when voice state cache isn't updated yet
         if (event.current.userId == selfId && oldChannelId == null) {
             return Mono.empty()
         }


### PR DESCRIPTION
## Summary
- prevent immediate disconnect on voice state events triggered by the bot itself

## Testing
- `./gradlew test` *(fails: superclass access check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840742202088322be4341f35670aaf0