### PR TITLE
Добавлена среда для unit-тестирования

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,4 +17,6 @@ jobs:
         run: chmod +x ./gradlew
       - name: Build with Gradle
         run: ./gradlew build
+      - name: Run unit tests
+        run: ./gradlew test
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,18 @@
 ```bash
 java -jar build/libs/discord-bot-1.0-SNAPSHOT.jar <DISCORD_TOKEN> <YOUTUBE_API_KEY>
 ```
+
+## Тестирование
+
+Для запуска unit-тестов выполните:
+
+```bash
+./gradlew test
+```
+
+В тестах токены Discord и YouTube можно мокировать, передавая фиктивные значения или
+используя переменные окружения. Сами сетевые запросы при необходимости легко
+заменяются на заглушки с помощью библиотеки MockK.
+
+Unit-тесты автоматически запускаются для каждого Pull Request благодаря
+GitHub Actions (см. `.github/workflows/pr.yml`).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation("org.xerial:sqlite-jdbc:3.40.1.0")
 
     testImplementation(kotlin("test"))
+    testImplementation("io.mockk:mockk:1.13.8")
 }
 
 kapt {
@@ -83,4 +84,8 @@ idea {
         sourceDirs.plusAssign(file("$buildDir/generated/source/kapt/main"))
         generatedSourceDirs.plusAssign(file("$buildDir/generated/source/kapt/main"))
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/src/test/kotlin/DatabaseTest.kt
+++ b/src/test/kotlin/DatabaseTest.kt
@@ -1,0 +1,14 @@
+import model.database.Database
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DatabaseTest {
+    @Test
+    fun `add and check guild`() {
+        val db = Database()
+        db.initDatabase()
+        val guildId = "testGuild"
+        db.addGuild(guildId)
+        assertTrue(db.existsGuild(guildId))
+    }
+}

--- a/src/test/kotlin/MessageServiceTest.kt
+++ b/src/test/kotlin/MessageServiceTest.kt
@@ -1,0 +1,85 @@
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
+import discord4j.core.spec.legacy.LegacyEmbedCreateSpec
+import discord4j.rest.util.Color
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import service.MessageService
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class MessageServiceTest {
+    private val service = MessageService()
+
+
+    @Test
+    fun `getTrackDescription formats text`() {
+        val info = AudioTrackInfo("Song", "Artist", 1000L, "abc", false, "uri")
+        val track = mockk<AudioTrack>()
+        every { track.info } returns info
+
+        val method = MessageService::class.java.getDeclaredMethod("getTrackDescription", AudioTrack::class.java)
+        method.isAccessible = true
+        val result = method.invoke(service, track) as String
+        assertEquals("[Song](https://www.youtube.com/watch?v=abc) - Artist", result)
+    }
+
+    @Test
+    fun `getTrackAdditionalInfo formats info`() {
+        val track = mockk<AudioTrack>()
+        every { track.duration } returns 125000L
+
+        val method = MessageService::class.java.getDeclaredMethod(
+            "getTrackAdditionalInfo",
+            AudioTrack::class.java,
+            Boolean::class.javaPrimitiveType,
+            Boolean::class.javaPrimitiveType
+        )
+        method.isAccessible = true
+        val result = method.invoke(service, track, true, false) as String
+        assertEquals("Трек длиной: 2 минут 5 секунд \n Повтор включен \n ", result)
+    }
+
+    @Test
+    fun `getStatus returns proper text`() {
+        val method = MessageService::class.java.getDeclaredMethod("getStatus", Boolean::class.javaPrimitiveType)
+        method.isAccessible = true
+        val stay = method.invoke(service, true) as String
+        val play = method.invoke(service, false) as String
+        assertEquals("Поставлено в очередь", stay)
+        assertEquals("Играющий трек", play)
+    }
+
+    @Test
+    fun `applyEmbedProperties sets values`() {
+        val embed = mockk<LegacyEmbedCreateSpec>(relaxed = true)
+        val method = MessageService::class.java.getDeclaredMethod(
+            "applyEmbedProperties",
+            LegacyEmbedCreateSpec::class.java,
+            String::class.java,
+            String::class.java,
+            String::class.java,
+            String::class.java,
+            Color::class.java,
+            Instant::class.java,
+            String::class.java,
+            String::class.java
+        )
+        method.isAccessible = true
+        val time = Instant.EPOCH
+        method.invoke(service, embed, "t", "d", "thumb", "foot", Color.RED, time, "img", "auth")
+
+        verify {
+            embed.setTitle("t")
+            embed.setDescription("d")
+            embed.setThumbnail("thumb")
+            embed.setFooter("foot", null)
+            embed.setColor(Color.RED)
+            embed.setTimestamp(time)
+            embed.setImage("img")
+            embed.setAuthor("auth", null, null)
+        }
+    }
+}

--- a/src/test/kotlin/RemoteModuleTest.kt
+++ b/src/test/kotlin/RemoteModuleTest.kt
@@ -1,0 +1,16 @@
+import di.remote.RemoteModule
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RemoteModuleTest {
+    @Test
+    fun `provided api key is stored in YouTubeImpl`() {
+        val key = "TEST_KEY"
+        val module = RemoteModule(key)
+        val impl = module.getYouTubeImpl()
+        val field = impl.javaClass.getDeclaredField("apiKey")
+        field.isAccessible = true
+        val value = field.get(impl) as String
+        assertEquals(key, value)
+    }
+}


### PR DESCRIPTION
## Summary
- добавлены примеры unit-тестов
- подключена библиотека MockK
- настроен запуск тестов через JUnit Platform
- восстановлен шаг сборки в workflow и добавлен запуск unit-тестов
- обновлён README с инструкциями по запуску тестов

## Testing
- `./gradlew build`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6840855c69a08322bb4cb7e088de4ddc