### PR TITLE
Add slash commands

### DIFF
--- a/src/main/kotlin/bot/Bot.kt
+++ b/src/main/kotlin/bot/Bot.kt
@@ -24,6 +24,7 @@ import di.remote.RemoteComponent
 import di.remote.RemoteModule
 import di.service.DaggerServiceComponent
 import di.service.ServiceComponent
+import bot.slash.SlashCommandManager
 import discord4j.core.DiscordClientBuilder
 import discord4j.core.GatewayDiscordClient
 import discord4j.gateway.intent.Intent
@@ -49,6 +50,7 @@ class Bot(id: String, private val apiKeyYouTube: String) {
 
         if (client != null) {
             Observers(commands).setEventObserver(client)
+            SlashCommandManager(client).register()
             clientGeneral = client
             println("Bot init!")
         }

--- a/src/main/kotlin/bot/slash/RelaySlashCommand.kt
+++ b/src/main/kotlin/bot/slash/RelaySlashCommand.kt
@@ -1,0 +1,20 @@
+package bot.slash
+
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.core.`object`.entity.channel.MessageChannel
+import discord4j.discordjson.json.ApplicationCommandRequest
+import reactor.core.publisher.Mono
+
+class RelaySlashCommand(
+    override val request: ApplicationCommandRequest,
+    private val buildMessage: (ChatInputInteractionEvent) -> String
+) : SlashCommand {
+    override fun handle(event: ChatInputInteractionEvent): Mono<Void> {
+        val commandMessage = buildMessage(event)
+        val sendCommand = event.interaction.channel
+            .ofType(MessageChannel::class.java)
+            .flatMap { channel -> channel.createMessage(commandMessage) }
+            .then()
+        return event.reply().withContent("Выполняю команду").withEphemeral(true).then(sendCommand)
+    }
+}

--- a/src/main/kotlin/bot/slash/SlashCommand.kt
+++ b/src/main/kotlin/bot/slash/SlashCommand.kt
@@ -1,0 +1,10 @@
+package bot.slash
+
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.discordjson.json.ApplicationCommandRequest
+import reactor.core.publisher.Mono
+
+interface SlashCommand {
+    val request: ApplicationCommandRequest
+    fun handle(event: ChatInputInteractionEvent): Mono<Void>
+}

--- a/src/main/kotlin/bot/slash/SlashCommandManager.kt
+++ b/src/main/kotlin/bot/slash/SlashCommandManager.kt
@@ -1,0 +1,87 @@
+package bot.slash
+
+import discord4j.core.GatewayDiscordClient
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.discordjson.json.ApplicationCommandRequest
+import discord4j.rest.interaction.GlobalCommandRegistrar
+import reactor.core.publisher.Mono
+
+class SlashCommandManager(private val client: GatewayDiscordClient) {
+
+    private val commands: List<SlashCommand> = listOf(
+        slash("ping", "Проверка работоспособности") { "!ping" },
+        slash("help", "Список команд") { "!help" },
+        slashWithOption("play", "Воспроизвести трек", "query", "Ссылка или название") {
+            val query = it.getOption("query").flatMap { opt -> opt.value.map { v -> v.raw } }.orElse("")
+            "!play $query"
+        },
+        slash("stop", "Остановить воспроизведение") { "!stop" },
+        slash("next", "Следующий трек") { "!next" },
+        slash("queue", "Очередь треков") { "!queue" },
+        slash("what", "Сейчас играет") { "!what" },
+        slash("loop", "Повтор текущего трека") { "!loop" },
+        slash("shuffle", "Перемешать очередь") { "!shuffle" },
+        slash("playlistloop", "Повтор плейлиста") { "!playlistloop" },
+        slashWithOption("jump", "Перейти к треку", "index", "Номер трека") {
+            val index = it.getOption("index").flatMap { o -> o.value.map { v -> v.raw } }.orElse("")
+            "!jump $index"
+        },
+        slashWithOption("delete", "Удалить трек из очереди", "index", "Номер трека") {
+            val index = it.getOption("index").flatMap { o -> o.value.map { v -> v.raw } }.orElse("")
+            "!delete $index"
+        },
+        slashWithOption("savefavorite", "Сохранить в избранное", "link", "Ссылка") {
+            val link = it.getOption("link").flatMap { o -> o.value.map { v -> v.raw } }.orElse("")
+            "!savefavorite $link"
+        },
+        slash("getfavorites", "Список избранного") { "!getfavorites" },
+        slashWithOption("pfavorite", "Воспроизвести избранное", "index", "Номер трека") {
+            val index = it.getOption("index").flatMap { o -> o.value.map { v -> v.raw } }.orElse("")
+            "!pfavorite $index"
+        },
+        slashWithOption("rmfavorite", "Удалить из избранного", "index", "Номер трека") {
+            val index = it.getOption("index").flatMap { o -> o.value.map { v -> v.raw } }.orElse("")
+            "!rmfavorite $index"
+        },
+        slash("nowfavorite", "Добавить текущий трек в избранное") { "!nowfavorite" }
+    )
+
+    fun register() {
+        val requests = commands.map { it.request }
+        GlobalCommandRegistrar.create(client.restClient, requests).registerCommands().blockLast()
+        client.on(ChatInputInteractionEvent::class.java)
+            .flatMap { event ->
+                commands.find { it.request.name() == event.commandName }?.handle(event) ?: Mono.empty()
+            }
+            .subscribe()
+    }
+
+    private fun slash(name: String, description: String, message: (ChatInputInteractionEvent) -> String): SlashCommand {
+        val request = ApplicationCommandRequest.builder()
+            .name(name)
+            .description(description)
+            .build()
+        return RelaySlashCommand(request, message)
+    }
+
+    private fun slashWithOption(
+        name: String,
+        description: String,
+        option: String,
+        optionDescription: String,
+        message: (ChatInputInteractionEvent) -> String
+    ): SlashCommand {
+        val optionData = discord4j.discordjson.json.ApplicationCommandOptionData.builder()
+            .name(option)
+            .description(optionDescription)
+            .type(discord4j.core.`object`.command.ApplicationCommandOption.Type.STRING.value)
+            .required(true)
+            .build()
+        val request = ApplicationCommandRequest.builder()
+            .name(name)
+            .description(description)
+            .addOption(optionData)
+            .build()
+        return RelaySlashCommand(request, message)
+    }
+}


### PR DESCRIPTION
## Summary
- implement slash command framework
- wire manager into bot initialization

## Testing
- `./gradlew build -x test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6840b6e331bc8322a9357ba0dfee897b