### PR TITLE
Добавлена аналитика сообщений

### DIFF
--- a/src/main/kotlin/bot/Observers.kt
+++ b/src/main/kotlin/bot/Observers.kt
@@ -23,6 +23,7 @@ internal class Observers(private val commands: MutableMap<String, Command>) {
     }
 
     private fun observeMessageEvents(client: GatewayDiscordClient) {
+        val analytics = Bot.serviceComponent.getAnalyticsService()
         client.eventDispatcher.on(MessageCreateEvent::class.java)
             .flatMap { event ->
                 val guildId = event.guildId.orElse(null)
@@ -31,7 +32,7 @@ internal class Observers(private val commands: MutableMap<String, Command>) {
                     musicManager.addGuild()
                     sendFirstMessage(event).subscribe()
                 }
-                processEvent(event)
+                analytics.log(event).then(processEvent(event) ?: Mono.empty())
             }
             .subscribeOn(Schedulers.parallel())
             .onErrorResume {

--- a/src/main/kotlin/di/service/ServiceComponent.kt
+++ b/src/main/kotlin/di/service/ServiceComponent.kt
@@ -4,6 +4,7 @@ import dagger.Component
 import service.GodmodeService
 import service.MessageService
 import service.VoiceChannelService
+import service.AnalyticsService
 import service.music.MusicService
 
 @Component(modules = [ServiceModule::class])
@@ -12,4 +13,5 @@ interface ServiceComponent {
     fun getMessageService(): MessageService
     fun getMusicService(): MusicService
     fun getVoiceChannelService(): VoiceChannelService
+    fun getAnalyticsService(): AnalyticsService
 }

--- a/src/main/kotlin/di/service/ServiceModule.kt
+++ b/src/main/kotlin/di/service/ServiceModule.kt
@@ -6,6 +6,7 @@ import service.GodmodeService
 import service.MessageService
 import service.music.MusicService
 import service.VoiceChannelService
+import service.AnalyticsService
 
 @Module
 class ServiceModule {
@@ -27,5 +28,10 @@ class ServiceModule {
     @Provides
     fun getVoiceChannelService(): VoiceChannelService {
         return VoiceChannelService()
+    }
+
+    @Provides
+    fun getAnalyticsService(): AnalyticsService {
+        return AnalyticsService()
     }
 }

--- a/src/main/kotlin/service/AnalyticsService.kt
+++ b/src/main/kotlin/service/AnalyticsService.kt
@@ -1,0 +1,21 @@
+package service
+
+import discord4j.core.event.domain.message.MessageCreateEvent
+import reactor.core.publisher.Mono
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.time.Instant
+
+class AnalyticsService(private val path: Path = Path.of("analytics/messages.log")) {
+    fun log(event: MessageCreateEvent): Mono<Void> {
+        return Mono.fromRunnable<Void> {
+            val guildId = event.guildId.map { it.asString() }.orElse("unknown")
+            val author = event.message.author.map { it.username }.orElse("unknown")
+            val content = event.message.content
+            val line = "${Instant.now()} $guildId $author: $content\n"
+            Files.createDirectories(path.parent)
+            Files.writeString(path, line, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+        }.onErrorResume { Mono.empty() }
+    }
+}

--- a/src/test/kotlin/AnalyticsServiceTest.kt
+++ b/src/test/kotlin/AnalyticsServiceTest.kt
@@ -1,0 +1,32 @@
+import discord4j.common.util.Snowflake
+import discord4j.core.event.domain.message.MessageCreateEvent
+import discord4j.core.`object`.entity.Message
+import discord4j.core.`object`.entity.User
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import service.AnalyticsService
+import java.util.*
+import kotlin.io.path.readText
+import kotlin.test.assertTrue
+
+class AnalyticsServiceTest {
+    @Test
+    fun `log writes message`() {
+        val dir = createTempDir()
+        val path = dir.toPath().resolve("log.txt")
+        val service = AnalyticsService(path)
+        val event = mockk<MessageCreateEvent>()
+        val message = mockk<Message>()
+        val user = mockk<User>()
+        every { event.message } returns message
+        every { event.guildId } returns Optional.of(Snowflake.of("1"))
+        every { message.author } returns Optional.of(user)
+        every { user.username } returns "user"
+        every { message.content } returns "hi"
+        service.log(event).block()
+        val text = path.readText()
+        assertTrue(text.contains("hi"))
+        assertTrue(text.contains("user"))
+    }
+}

--- a/src/test/kotlin/GodmodeServiceTest.kt
+++ b/src/test/kotlin/GodmodeServiceTest.kt
@@ -29,6 +29,7 @@ class GodmodeServiceTest {
             override fun getMessageService() = messageService
             override fun getMusicService() = mockk<MusicService>(relaxed = true)
             override fun getVoiceChannelService() = mockk<VoiceChannelService>(relaxed = true)
+            override fun getAnalyticsService() = mockk<service.AnalyticsService>(relaxed = true)
         }
         val field = Bot::class.java.getDeclaredField("serviceComponent")
         field.isAccessible = true

--- a/src/test/kotlin/MusicServiceAdditionalTest.kt
+++ b/src/test/kotlin/MusicServiceAdditionalTest.kt
@@ -27,6 +27,7 @@ class MusicServiceAdditionalTest {
             override fun getMessageService() = messageService
             override fun getMusicService() = mockk<MusicService>(relaxed = true)
             override fun getVoiceChannelService() = mockk<VoiceChannelService>(relaxed = true)
+            override fun getAnalyticsService() = mockk<service.AnalyticsService>(relaxed = true)
         }
         val remoteComponent = di.remote.RemoteComponent { mockk(relaxed = true) }
         val databaseComponent = object : di.database.DatabaseComponent {


### PR DESCRIPTION
## Изменения
- создан `AnalyticsService` для записи всех сообщений в файл
- сервис добавлен в Dagger-модули
- логика обработки сообщений обновлена для отправки данных в аналитику
- написан тест `AnalyticsServiceTest`
- обновлены существующие тесты с учётом нового сервиса

## Тестирование
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6840bfd444a08322903fd8bd5540225b