### PR TITLE
Исправлено преждевременное отключение музыки при выходе пользователей

### DIFF
--- a/src/main/kotlin/bot/Observers.kt
+++ b/src/main/kotlin/bot/Observers.kt
@@ -84,16 +84,13 @@ internal class Observers(private val commands: MutableMap<String, Command>) {
         currentChannelId: Snowflake?
     ): Mono<Void> {
         if (oldChannelId != null && currentChannelId == null) {
-            return isBotInVoiceChannel(event, client)
-                .flatMap { botInVoice ->
-                    if (!botInVoice) {
-                        stopMusic(event.current.guildId)
-                    } else {
-                        Mono.empty<Void>()
-                    }
-                }
+            return if (event.current.userId == client.selfId) {
+                stopMusic(event.current.guildId)
+            } else {
+                Mono.empty()
+            }
         }
-        return Mono.empty<Void>()
+        return Mono.empty()
     }
 
     private fun handleVoiceJoining(

--- a/src/test/kotlin/ObserversTest.kt
+++ b/src/test/kotlin/ObserversTest.kt
@@ -1,0 +1,62 @@
+import bot.Observers
+import discord4j.common.util.Snowflake
+import discord4j.core.GatewayDiscordClient
+import discord4j.core.event.domain.VoiceStateUpdateEvent
+import discord4j.core.`object`.VoiceState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import manager.GuildManager
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import reactor.core.publisher.Mono
+
+class ObserversTest {
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(GuildManager)
+    }
+
+    @Test
+    fun `handleVoiceLeaving ignores non bot users`() {
+        val observers = Observers(mutableMapOf())
+        val method = Observers::class.java.getDeclaredMethod(
+            "handleVoiceLeaving",
+            VoiceStateUpdateEvent::class.java,
+            GatewayDiscordClient::class.java,
+            Snowflake::class.java,
+            Snowflake::class.java
+        ).apply { isAccessible = true }
+
+        val event = mockk<VoiceStateUpdateEvent>()
+        val client = mockk<GatewayDiscordClient>()
+        val voiceState = mockk<VoiceState>()
+        val guildId = Snowflake.of(1L)
+        val userId = Snowflake.of(2L)
+        val botId = Snowflake.of(3L)
+
+        every { event.current } returns voiceState
+        every { event.client } returns client
+        every { voiceState.guildId } returns guildId
+        every { voiceState.userId } returns userId
+        every { client.selfId } returns botId
+        every { client.self } returns Mono.error(RuntimeException("should not be called"))
+
+        mockkObject(GuildManager)
+        every { GuildManager.getGuildMusicManager(any<Snowflake>()) } throws AssertionError("should not be called")
+
+        val result = method.invoke(
+            observers,
+            event,
+            client,
+            Snowflake.of(4L),
+            null
+        ) as Mono<*>
+
+        assertDoesNotThrow { result.blockOptional() }
+    }
+}
+


### PR DESCRIPTION
## Изменения
- исключил остановку проигрывания при выходе из канала участников, отличных от бота
- добавил модульный тест для проверки корректной обработки события VoiceStateUpdate

## Тесты
- ./gradlew build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_69090b9865b483229f3e38bc7d79a0e8